### PR TITLE
LM-5152 Add --compact-methods-binding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
 * `--disallow-invalid-constructors`: Give an error when constructors use `this`
   before `super` or omit the `super` call in a subclass.
 
-[Amended options](./docs/amendments.md):
+[Options amended to the original `decaffeinate`](./docs/amendments.md):
 * `--bind-methods-after-super-call`: Bind instance methods after `super` constructor call to avoid
   the invalid constructor error (see `--disallow-invalid-constructors`)
-* `--compact-methods-binding`: Do instance methods binding using `Object.prototype._bindMethods`.
+* `--compact-methods-binding`: Do instance methods binding via `this._bindMethods()` call in a constructor.
   If you use this options, you must ensure existence of `Object.prototype._bindMethods` in the application.
 * `--correct-static-generator-methods`: provides a correct syntax on converting a static generator method.
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
 [Amended options](./docs/amendments.md):
 * `--bind-methods-after-super-call`: Bind instance methods after `super` constructor call to avoid
   the invalid constructor error (see `--disallow-invalid-constructors`)
-* `--compact-method-binding`: Do instance methods binding using `Object.prototype._bindMethods`.
+* `--compact-methods-binding`: Do instance methods binding using `Object.prototype._bindMethods`.
   If you use this options, you must ensure existence of `Object.prototype._bindMethods` in the application.
 * `--correct-static-generator-methods`: provides a correct syntax on converting a static generator method.
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,12 @@ decaffeinate could be improved, feel free to file an issue on the [issues] page.
   workaround code to allow `this` before `super` in constructors.
 * `--disallow-invalid-constructors`: Give an error when constructors use `this`
   before `super` or omit the `super` call in a subclass.
-* `--bind-methods-after-super-call`: Bind methods after `super` constructor call to avoid
+
+[Amended options](./docs/amendments.md):
+* `--bind-methods-after-super-call`: Bind instance methods after `super` constructor call to avoid
   the invalid constructor error (see `--disallow-invalid-constructors`)
+* `--compact-method-binding`: Do instance methods binding using `Object.prototype._bindMethods`.
+  If you use this options, you must ensure existence of `Object.prototype._bindMethods` in the application.
 * `--correct-static-generator-methods`: provides a correct syntax on converting a static generator method.
 
 For more usage details, see the output of `decaffeinate --help`.

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -8,7 +8,7 @@
 For some reason the original `decaffeinate` converts a static method-generator to a wrong syntax: `*static methodName()` instead of `static *methodName()`.
 
 `--correct-static-generator-methods` option fixes this problem:
-  
+
 ```javascript
 class MyClass
   @m: ->
@@ -112,7 +112,7 @@ class Desc extends Base {
 }
 ```
 
-Use of this option requres the application to be provided with `Object.prototype._bindMethods` implementated as follows:
+Use of this option requires the application to be provided with `Object.prototype._bindMethods` implemented as follows:
 ```javascript
 Object.defineProperty(Object.prototype, '_bindMethods', {
   enumerable: false,

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -18,9 +18,9 @@ The original `decaffeinate` converts Coffeescript "fat arrow" instance [methods 
 
 To address this problem `--bind-methods-after-super-call` option has been added.
 
-### --compact-method-binding
+### --compact-methods-binding
 
-There is also one more extra option - `--compact-method-binding`. 
+There is also one more extra option - `--compact-methods-binding`.
 
 The option causes all instance methods binding in a single line: `this._bindMethods('method1', 'method2');`
 

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -1,0 +1,49 @@
+# This document describes things which have been added to the [original decaffeinate](https://github.com/decaffeinate/decaffeinate).
+
+
+## Static generator methods
+
+### --correct-static-generator-methods
+
+For some reason the original `decaffeinate` converts a static method-generator to a wrong syntax: `*static methodName()` instead of `static *methodName()`.
+
+`--correct-static-generator-methods` option fixes this problem.
+
+
+## Bound instance methods
+
+### --bind-methods-after-super-call
+
+The original `decaffeinate` converts Coffeescript "fat arrow" instance [methods to method binding BEFORE `super` call](https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md#javascript-after-decaffeinate). This is incorrect in a ES6 class.
+
+To address this problem `--bind-methods-after-super-call` option has been added.
+
+### --compact-method-binding
+
+There is also one more extra option - `--compact-method-binding`. 
+
+The option causes all instance methods binding in a single line: `this._bindMethods('method1', 'method2');`
+
+Use of this option requres the application to be provided with `Object.prototype._bindMethods` implementated as follows:
+```
+Object.defineProperty(Object.prototype, '_bindMethods', {
+  enumerable: false,
+  configurable: false,
+  writable: false,
+  value: function(...methods) {
+    methods.forEach((m) => {
+      const original = this[m];
+      this[m] = this[m].bind(this);
+      this[m].unbound = original;
+    });
+  }
+});
+```
+
+In addition the wrapper for every bound method provides its unbound version accessible via a standard syntax: `obj.method.unbound`.
+
+_Basically it makes sense to have an unbound method version under `obj.method` and its bound version under `obj.method.bound`. This approach is better, because it would allow to call an unbound method in a natural way - `obj.method()`. But it would force you to correct all the places where bound methods were already used in your Coffeescript program._
+
+
+
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,10 @@ function parseArguments(args: Array<string>): CLIOptions {
         baseOptions.bindMethodsAfterSuperCall = true;
         break;
 
+      case '--compact-methods-binding':
+        baseOptions.compactMethodsBinding = true;
+        break;
+
       case '--correct-static-generator-methods':
         baseOptions.correctStaticGeneratorMethods = true;
         break;

--- a/src/options.ts
+++ b/src/options.ts
@@ -18,6 +18,7 @@ export type Options = {
   disableBabelConstructorWorkaround?: boolean,
   disallowInvalidConstructors?: boolean,
   bindMethodsAfterSuperCall?: boolean,
+  compactMethodsBinding?: boolean,
   correctStaticGeneratorMethods?: boolean,
 };
 
@@ -41,5 +42,6 @@ export const DEFAULT_OPTIONS: Options = {
   disableBabelConstructorWorkaround: false,
   disallowInvalidConstructors: false,
   bindMethodsAfterSuperCall: false,
+  compactMethodsBinding: false,
   correctStaticGeneratorMethods: false,
 };

--- a/src/stages/main/patchers/ClassBlockPatcher.ts
+++ b/src/stages/main/patchers/ClassBlockPatcher.ts
@@ -54,14 +54,9 @@ export default class ClassBlockPatcher extends BlockPatcher {
         }
 
         const bindMethods = () => {
-          if (this.shouldCompactMethodsBinding()) {
-            const boundMethodNames = boundMethods.map((m) => `'${getNameForMethod(m)}'`).join(', ');
-            constructor += `${methodBodyIndent}this._bindMethods(${boundMethodNames})\n`;
-          } else {
-            boundMethods.forEach(method => {
-              constructor += `${methodBodyIndent}${getBindingCodeForMethod(method)};\n`;
-            });
-          }
+          this.getBindingCodeForAllBoundMethods().forEach((methodBindingCode) => {
+            constructor +=  `${methodBodyIndent}${methodBindingCode};\n`;
+          });
         };
 
         if (!this.shouldBindMethodsAfterSuperCall()) { bindMethods(); }
@@ -74,6 +69,22 @@ export default class ClassBlockPatcher extends BlockPatcher {
         this.prependLeft(insertionPoint, constructor);
       }
     }
+  }
+
+  getBindingCodeForAllBoundMethods(): Array<string> {
+    const boundMethods = this.boundInstanceMethods();
+    const result: Array<string> = [];
+
+    if (this.shouldCompactMethodsBinding()) {
+      const boundMethodNames = boundMethods.map((m) => `'${getNameForMethod(m)}'`).join(', ');
+      result.push(`this._bindMethods(${boundMethodNames})`);
+    } else {
+      boundMethods.forEach(method => {
+        result.push(getBindingCodeForMethod(method));
+      });
+    }
+
+    return result;
   }
 
   shouldAllowInvalidConstructors(): boolean {

--- a/src/stages/main/patchers/ConstructorPatcher.ts
+++ b/src/stages/main/patchers/ConstructorPatcher.ts
@@ -5,7 +5,6 @@ import { REMOVE_BABEL_WORKAROUND } from '../../../suggestions';
 import babelConstructorWorkaroundLines from '../../../utils/babelConstructorWorkaroundLines';
 import containsDescendant from '../../../utils/containsDescendant';
 import containsSuperCall from '../../../utils/containsSuperCall';
-import getBindingCodeForMethod from '../../../utils/getBindingCodeForMethod';
 import getInvalidConstructorErrorMessage from '../../../utils/getInvalidConstructorErrorMessage';
 import { isFunction } from '../../../utils/types';
 import ClassBlockPatcher from './ClassBlockPatcher';
@@ -115,9 +114,7 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
 
   getBindings(): Array<string> {
     if (!this._bindings) {
-      let boundMethods = this.getEnclosingClassBlockPatcher().boundInstanceMethods();
-      let bindings = boundMethods.map(getBindingCodeForMethod);
-      this._bindings = bindings;
+      this._bindings = this.getEnclosingClassBlockPatcher().getBindingCodeForAllBoundMethods();
     }
     return this._bindings;
   }

--- a/src/stages/main/patchers/ConstructorPatcher.ts
+++ b/src/stages/main/patchers/ConstructorPatcher.ts
@@ -28,8 +28,7 @@ export default class ConstructorPatcher extends ObjectBodyMemberPatcher {
     this.checkForConstructorErrors();
 
     if (this.expression.body) {
-      let linesToInsert = this.getLinesToInsert();
-      this.expression.body.insertStatementsAtIndex(linesToInsert, 0);
+      this.expression.body.insertStatementsAtIndex(this.getLinesToInsert(), this.getIndexOfSuperStatement() + 1);
       super.patch(options);
     } else {
       super.patch(options);

--- a/src/utils/getBindingCodeForMethod.ts
+++ b/src/utils/getBindingCodeForMethod.ts
@@ -1,12 +1,19 @@
 import ClassAssignOpPatcher from '../stages/main/patchers/ClassAssignOpPatcher';
 import IdentifierPatcher from '../stages/main/patchers/IdentifierPatcher';
 
-export default function getBindingCodeForMethod(method: ClassAssignOpPatcher): string {
-  let accessCode;
+function getAccessCodeForMethod(method: ClassAssignOpPatcher): string {
   if (method.key instanceof IdentifierPatcher) {
-    accessCode = `.${method.key.node.data}`;
+    return `.${method.key.node.data}`;
   } else {
-    accessCode = `[${method.key.getRepeatCode()}]`;
+    return `[${method.key.getRepeatCode()}]`;
   }
+}
+
+export function getNameForMethod(method: ClassAssignOpPatcher): string {
+  return getAccessCodeForMethod(method).substr(1);
+}
+
+export default function getBindingCodeForMethod(method: ClassAssignOpPatcher): string {
+  const accessCode = getAccessCodeForMethod(method);
   return `this${accessCode} = this${accessCode}.bind(this)`;
 }


### PR DESCRIPTION
The main goal of this PR is to provide a ["syntax sugar" for compact method binding](https://github.com/locomote/decaffeinate/pull/2/files#diff-7c42f00bca30913b18c2c22a23ec3110R106) (with `--compact-methods-binding` option).

Aside there is an improvement of earlier added `--bind-methods-after-super-call` option. Till now it worked only when the constructor was absent in a Coffeescript class, since now - when the constructor is present as well.